### PR TITLE
fix(http-client): preserve baseUrl path component (TMDB /3 404)

### DIFF
--- a/src/utils/http-client.ts
+++ b/src/utils/http-client.ts
@@ -89,13 +89,32 @@ export class HttpClient {
   }
 
   /**
+   * Resolve a request path against the base URL, preserving any path component
+   * in the base. `new URL('/x', 'https://h/3')` treats the leading slash as
+   * root-relative and drops the `/3`; when the base carries its own path (e.g.
+   * TMDB's `/3`, Google Books' `/books/v1`) we strip the leading slash and join
+   * against a slash-terminated base so the base path survives. Origin-only bases
+   * and absolute/empty paths fall through to plain resolution unchanged.
+   */
+  private resolveUrl(path: string): URL {
+    if (this.baseUrl && path.startsWith('/')) {
+      const basePath = new URL(this.baseUrl).pathname.replace(/\/+$/, '');
+      if (basePath !== '') {
+        const base = this.baseUrl.endsWith('/') ? this.baseUrl : `${this.baseUrl}/`;
+        return new URL(path.slice(1), base);
+      }
+    }
+    return new URL(path, this.baseUrl);
+  }
+
+  /**
    * Build URL with query parameters
    */
   private buildUrl(
     path: string,
     params?: Record<string, string | number | boolean | undefined>
   ): string {
-    const url = new URL(path, this.baseUrl);
+    const url = this.resolveUrl(path);
 
     // Default params first, then per-call params so callers can override defaults.
     const merged = { ...this.params, ...params };

--- a/tests/sources/tmdb.test.ts
+++ b/tests/sources/tmdb.test.ts
@@ -306,6 +306,9 @@ describe('TMDBSource', () => {
 
       const calledUrl = String(mockRequest.mock.calls[0][0]);
       const calledHeaders = (mockRequest.mock.calls[0][1] as any).headers;
+      // The /3 API-version prefix must survive URL construction (regression: a
+      // leading-slash path dropped it, yielding 404s on every TMDB request).
+      expect(calledUrl).toContain('https://api.themoviedb.org/3/search/movie');
       expect(calledUrl).toContain(`api_key=${V3_KEY}`);
       expect(calledHeaders.Authorization).toBeUndefined();
     });

--- a/tests/utils/http-client.test.ts
+++ b/tests/utils/http-client.test.ts
@@ -80,4 +80,66 @@ describe('HttpClient', () => {
       expect(calledUrl).toBe('https://api.example.com/plain');
     });
   });
+
+  describe('baseUrl with a path component', () => {
+    it('preserves the base path for a leading-slash path (does not drop /3)', async () => {
+      const client = new HttpClient(
+        'test',
+        { baseUrl: 'https://api.themoviedb.org/3' },
+        logger,
+        rateLimiter
+      );
+      mockJsonResponse({ ok: true });
+
+      await client.get('/search/movie', { params: { query: 'matrix' } });
+
+      const calledUrl = String(mockRequest.mock.calls[0][0]);
+      expect(calledUrl).toContain('https://api.themoviedb.org/3/search/movie');
+    });
+
+    it('preserves a multi-segment base path (google-books /books/v1)', async () => {
+      const client = new HttpClient(
+        'test',
+        { baseUrl: 'https://www.googleapis.com/books/v1' },
+        logger,
+        rateLimiter
+      );
+      mockJsonResponse({ ok: true });
+
+      await client.get('/volumes');
+
+      const calledUrl = String(mockRequest.mock.calls[0][0]);
+      expect(calledUrl).toBe('https://www.googleapis.com/books/v1/volumes');
+    });
+
+    it('leaves an origin-only baseUrl unchanged', async () => {
+      const client = new HttpClient(
+        'test',
+        { baseUrl: 'https://openlibrary.org' },
+        logger,
+        rateLimiter
+      );
+      mockJsonResponse({ ok: true });
+
+      await client.get('/search.json');
+
+      const calledUrl = String(mockRequest.mock.calls[0][0]);
+      expect(calledUrl).toBe('https://openlibrary.org/search.json');
+    });
+
+    it('does not append a trailing slash for an empty path against a path base (graphql POST)', async () => {
+      const client = new HttpClient(
+        'test',
+        { baseUrl: 'https://api.hardcover.app/v1/graphql' },
+        logger,
+        rateLimiter
+      );
+      mockJsonResponse({ ok: true });
+
+      await client.post('', { query: '{ me { id } }' });
+
+      const calledUrl = String(mockRequest.mock.calls[0][0]);
+      expect(calledUrl).toBe('https://api.hardcover.app/v1/graphql');
+    });
+  });
 });


### PR DESCRIPTION
## What & why

Follow-up to #8. After deploying #8 to the homelab, the deployed log — now visible thanks to #8's observability fix — showed the real symptom is a **404**, not the **401** the original diagnosis in #7 assumed (that 401 was an inference the old silent code could never confirm).

**Root cause:** `HttpClient.buildUrl` did `new URL('/search/movie', 'https://api.themoviedb.org/3')`. A leading-slash path is root-relative, so `new URL` **drops the `/3`** — every TMDB request hit `api.themoviedb.org/search/movie` (404) instead of `/3/search/movie`. The auth fix in #8 was necessary but insufficient: the path was wrong regardless of the auth scheme. The same bug **latently broke google-books** (`/books/v1` dropped identically).

## Fix

A `resolveUrl` helper preserves a base path component: when `baseUrl` has a path and the call path is root-relative, strip the leading slash and join against a slash-terminated base. Origin-only bases (open-library, goodreads) and empty-path POSTs (hardcover GraphQL) fall through to plain resolution, unchanged.

## Testing

- `npm run lint` clean · `npm run build` ✓ · **102/102 tests** (+4 new `buildUrl` path cases; the TMDB v3 test strengthened to assert `/3/search/movie`).
- Empirical confirmation: `new URL('/search/movie', '…/3')` drops `/3` (verified); TMDB routing `/3/search/movie` → 401, `/search/movie` → 404 — matching the deployed log exactly.
- End-to-end re-verified on the Unraid deployment after merge.

Fixes #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP client URL construction to correctly preserve path components from base URLs when making requests.

* **Tests**
  * Extended test coverage for HTTP client URL resolution with various path segment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->