### PR TITLE
feat(tools): response-shaping toggles to tame context bombs (closes #6, #30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ Look up book metadata by title, author, or ISBN.
 
 **Output:** Book metadata including title, authors, ISBN, genres, page count, description, cover URL, series information, and ratings.
 
+Optional `compact: true` trims the response — nulls `description` and drops the noisy `shelves`/`subjects` arrays (the bulk of the payload), keeping genres, tropes, series, ratings, cover, and identifiers. Useful for batch lookups that would otherwise exceed inline token limits.
+
 ### lookup_movie
 
 Look up movie metadata by title and optional year.
@@ -171,6 +173,8 @@ Look up movie metadata by title and optional year.
 ```
 
 **Output:** Movie metadata including title, year, runtime, genres, description, cast, director, collection info, ratings, and watch providers.
+
+By default the large ~100-region `watch_providers` map is **omitted** to keep responses compact. To include it, pass `include_watch_providers: true`, or restrict it to specific regions with `watch_provider_regions: ["US"]` (which implies inclusion).
 
 ### lookup_tv
 

--- a/src/tools/batch-lookup.ts
+++ b/src/tools/batch-lookup.ts
@@ -12,6 +12,8 @@ const BatchBookItemSchema = z.object({
   title: z.string().min(1),
   author: z.string().optional(),
   isbn: z.string().optional(),
+  compact: z.boolean().default(false)
+    .describe('Trim each book: null description, drop shelves/subjects (cuts most of the payload)'),
 });
 
 const BatchMovieItemSchema = z.object({
@@ -19,6 +21,10 @@ const BatchMovieItemSchema = z.object({
   title: z.string().min(1),
   year: z.number().int().optional(),
   tmdb_id: z.number().int().optional(),
+  include_watch_providers: z.boolean().default(false)
+    .describe('Include the ~100-region watch-providers map (off by default — large)'),
+  watch_provider_regions: z.array(z.string()).optional()
+    .describe('Restrict watch_providers to these ISO country codes, e.g. ["US"]. Implies inclusion.'),
 });
 
 const BatchTVItemSchema = z.object({
@@ -152,6 +158,7 @@ export class BatchLookupTool {
             title: item.title,
             author: item.author,
             isbn: item.isbn,
+            compact: item.compact,
           });
           break;
 
@@ -160,6 +167,8 @@ export class BatchLookupTool {
             title: item.title,
             year: item.year,
             tmdb_id: item.tmdb_id,
+            include_watch_providers: item.include_watch_providers,
+            watch_provider_regions: item.watch_provider_regions,
           });
           break;
 

--- a/src/tools/lookup-book.ts
+++ b/src/tools/lookup-book.ts
@@ -16,7 +16,24 @@ export const LookupBookInputSchema = z.object({
     .array(z.enum(['open_library', 'google_books', 'goodreads', 'hardcover']))
     .optional()
     .describe('Sources to query (defaults to all available)'),
+  compact: z.boolean().default(false)
+    .describe('Trim the response: null the description and drop shelves/subjects (the bulk of the payload), keeping genres/tropes/series/ratings/cover/identifiers.'),
 });
+
+/**
+ * Trim the heaviest, lowest-signal fields from a book result — the full
+ * description (often 500+ words) and the noisy shelves/subjects arrays — which
+ * together dominate batch payloads. Keeps the high-signal fields. Returns a new
+ * object; never mutates the input.
+ */
+export function compactBookResult(result: BookResult): BookResult {
+  return {
+    ...result,
+    description: null,
+    shelves: [],
+    subjects: [],
+  };
+}
 
 export interface BookSources {
   openLibrary: OpenLibrarySource;
@@ -135,7 +152,7 @@ export class LookupBookTool {
       duration_ms: Date.now() - startTime,
     });
 
-    return bookResult;
+    return input.compact ? compactBookResult(bookResult) : bookResult;
   }
 
   private async searchOpenLibrary(

--- a/src/tools/lookup-movie.ts
+++ b/src/tools/lookup-movie.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { MovieResult, LookupMovieInput } from '../types/movie.js';
+import type { MovieResult, LookupMovieInput, RegionalWatchProviders } from '../types/movie.js';
 import { TMDBSource } from '../sources/tmdb.js';
 import { Logger } from '../utils/logger.js';
 
@@ -9,7 +9,38 @@ export const LookupMovieInputSchema = z.object({
     .describe('Release year (improves matching accuracy)'),
   tmdb_id: z.number().int().positive().optional()
     .describe('TMDB ID if known (preferred for exact match)'),
+  include_watch_providers: z.boolean().default(false)
+    .describe('Include the regional watch-providers map (large — ~100 regions). Off by default to keep responses compact.'),
+  watch_provider_regions: z.array(z.string()).optional()
+    .describe('Restrict watch_providers to these ISO country codes, e.g. ["US"]. Implies inclusion.'),
 });
+
+/**
+ * Shape the regional watch-providers map per the caller's request. The full map
+ * spans ~100 region keys and dominates the movie payload (a context bomb for
+ * agents), so it is omitted unless explicitly asked for. A region filter implies
+ * inclusion. Returns a new object — never mutates the (possibly cached) input.
+ */
+export function shapeWatchProviders(
+  providers: RegionalWatchProviders,
+  opts: { includeWatchProviders: boolean; watchProviderRegions?: string[] }
+): RegionalWatchProviders {
+  const hasRegionFilter = !!opts.watchProviderRegions && opts.watchProviderRegions.length > 0;
+  if (!opts.includeWatchProviders && !hasRegionFilter) {
+    return {};
+  }
+  if (hasRegionFilter) {
+    const wanted = new Set(opts.watchProviderRegions!.map((r) => r.toUpperCase()));
+    const filtered: RegionalWatchProviders = {};
+    for (const [region, data] of Object.entries(providers)) {
+      if (wanted.has(region.toUpperCase())) {
+        filtered[region] = data;
+      }
+    }
+    return filtered;
+  }
+  return providers;
+}
 
 export class LookupMovieTool {
   private tmdb: TMDBSource;
@@ -78,6 +109,14 @@ export class LookupMovieTool {
       duration_ms: Date.now() - startTime,
     });
 
-    return result;
+    // Trim the watch-providers map (off by default) before returning. Return a
+    // new object so the cached MovieResult is never mutated.
+    return {
+      ...result,
+      watch_providers: shapeWatchProviders(result.watch_providers, {
+        includeWatchProviders: input.include_watch_providers,
+        watchProviderRegions: input.watch_provider_regions,
+      }),
+    };
   }
 }

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -51,6 +51,7 @@ export const LookupBookInputSchema = z.object({
   author: z.string().optional(),
   isbn: z.string().optional(),
   sources: z.array(BookSourceSchema).optional(),
+  compact: z.boolean().default(false),
 });
 export type LookupBookInput = z.infer<typeof LookupBookInputSchema>;
 

--- a/src/types/movie.ts
+++ b/src/types/movie.ts
@@ -50,6 +50,8 @@ export const LookupMovieInputSchema = z.object({
   title: z.string().min(1, 'Title is required'),
   year: z.number().int().min(1800).max(2100).optional(),
   tmdb_id: z.number().int().positive().optional(),
+  include_watch_providers: z.boolean().default(false),
+  watch_provider_regions: z.array(z.string()).optional(),
 });
 export type LookupMovieInput = z.infer<typeof LookupMovieInputSchema>;
 

--- a/tests/tools/response-shaping.test.ts
+++ b/tests/tools/response-shaping.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { shapeWatchProviders, LookupMovieTool } from '../../src/tools/lookup-movie.js';
+import { compactBookResult } from '../../src/tools/lookup-book.js';
+import { Logger } from '../../src/utils/logger.js';
+import type { TMDBSource } from '../../src/sources/tmdb.js';
+import type { MovieResult, RegionalWatchProviders } from '../../src/types/movie.js';
+import type { BookResult } from '../../src/types/book.js';
+
+const PROVIDERS: RegionalWatchProviders = {
+  US: { stream: ['Netflix'], rent: ['Amazon'] },
+  GB: { stream: ['Now TV'] },
+  DE: { buy: ['Apple TV'] },
+};
+
+describe('shapeWatchProviders (#30)', () => {
+  it('omits all providers when include is false and no regions given', () => {
+    expect(shapeWatchProviders(PROVIDERS, { includeWatchProviders: false })).toEqual({});
+  });
+
+  it('returns all providers when include is true and no regions given', () => {
+    expect(shapeWatchProviders(PROVIDERS, { includeWatchProviders: true })).toEqual(PROVIDERS);
+  });
+
+  it('treats a region filter as implicit inclusion (even when include is false)', () => {
+    const out = shapeWatchProviders(PROVIDERS, {
+      includeWatchProviders: false,
+      watchProviderRegions: ['US'],
+    });
+    expect(Object.keys(out)).toEqual(['US']);
+    expect(out.US).toEqual(PROVIDERS.US);
+  });
+
+  it('matches region codes case-insensitively', () => {
+    const out = shapeWatchProviders(PROVIDERS, {
+      includeWatchProviders: true,
+      watchProviderRegions: ['us', 'de'],
+    });
+    expect(Object.keys(out).sort()).toEqual(['DE', 'US']);
+  });
+
+  it('returns an empty map when requested regions are not present', () => {
+    const out = shapeWatchProviders(PROVIDERS, {
+      includeWatchProviders: true,
+      watchProviderRegions: ['ZZ'],
+    });
+    expect(out).toEqual({});
+  });
+
+  it('does not mutate the input map', () => {
+    const copy = JSON.parse(JSON.stringify(PROVIDERS));
+    shapeWatchProviders(PROVIDERS, { includeWatchProviders: false });
+    expect(PROVIDERS).toEqual(copy);
+  });
+});
+
+function makeBook(): BookResult {
+  return {
+    title: 'Dune',
+    author: 'Frank Herbert',
+    authors: ['Frank Herbert'],
+    isbn_10: null,
+    isbn_13: null,
+    genres: ['Science Fiction'],
+    subjects: ['Politics', 'Desert', 'Spice', 'noise'],
+    tropes: ['chosen one'],
+    shelves: ['sci-fi', 'to-read', 'owned', 'favorites'],
+    page_count: 412,
+    publish_date: '1965',
+    publisher: 'Chilton',
+    description: 'A long 500-word description that bloats the response...',
+    cover_url: null,
+    series: { name: 'Dune', position: 1, total_books: 6 },
+    ratings: {},
+    identifiers: { open_library: null, goodreads: null, google_books: null, hardcover: null },
+    source_urls: { goodreads: null, open_library: null, google_books: null, hardcover: null },
+    _meta: { sources: ['open_library'], cached: false, timestamp: '2026-06-16T00:00:00.000Z' } as never,
+  };
+}
+
+describe('compactBookResult (#6)', () => {
+  it('nulls the description and empties shelves and subjects', () => {
+    const out = compactBookResult(makeBook());
+    expect(out.description).toBeNull();
+    expect(out.shelves).toEqual([]);
+    expect(out.subjects).toEqual([]);
+  });
+
+  it('keeps the high-signal fields (genres, tropes, series, ratings, title)', () => {
+    const out = compactBookResult(makeBook());
+    expect(out.genres).toEqual(['Science Fiction']);
+    expect(out.tropes).toEqual(['chosen one']);
+    expect(out.series.name).toBe('Dune');
+    expect(out.title).toBe('Dune');
+  });
+
+  it('does not mutate the input result', () => {
+    const book = makeBook();
+    compactBookResult(book);
+    expect(book.description).not.toBeNull();
+    expect(book.shelves.length).toBeGreaterThan(0);
+  });
+});
+
+function makeMovie(): MovieResult {
+  return {
+    title: 'The Matrix', original_title: 'The Matrix', year: 1999,
+    release_date: '1999-03-31', runtime_minutes: 136, genres: ['Action'],
+    description: 'desc', tagline: null, poster_url: null, backdrop_url: null,
+    director: 'Lana Wachowski', directors: ['Lana Wachowski'], cast: [],
+    collection: { name: null, position: null, total_films: null },
+    ratings: {},
+    watch_providers: { US: { stream: ['Netflix'] }, GB: { stream: ['Now TV'] } },
+    identifiers: { tmdb: 603, imdb: null },
+    _meta: { source: 'tmdb', cached: false, timestamp: '2026-06-16T00:00:00.000Z' },
+  };
+}
+
+describe('LookupMovieTool watch_providers wiring (#30)', () => {
+  function toolReturning(movie: MovieResult): LookupMovieTool {
+    const tmdb = {
+      searchMovie: async () => 603,
+      getMovieDetails: async () => movie,
+    } as unknown as TMDBSource;
+    return new LookupMovieTool(tmdb, new Logger('test'));
+  }
+
+  it('omits watch_providers by default (opt-in compact)', async () => {
+    const res = await toolReturning(makeMovie()).execute({
+      title: 'The Matrix', include_watch_providers: false,
+    });
+    expect(res.watch_providers).toEqual({});
+  });
+
+  it('includes only the requested region when watch_provider_regions is set', async () => {
+    const res = await toolReturning(makeMovie()).execute({
+      title: 'The Matrix', include_watch_providers: false, watch_provider_regions: ['US'],
+    });
+    expect(Object.keys(res.watch_providers)).toEqual(['US']);
+  });
+});


### PR DESCRIPTION
## What

Opt-in response-shaping to tame the "context bomb" payloads that blow Claude Code's tool-result token limits (results get persisted to disk instead of shown inline; agents burn their window). Both fixes mirror the existing TV `include_seasons`/`include_episodes` toggle pattern.

## #30 — movie `watch_providers` (single + batch)

The ~100-region `watch_providers` map dominates the movie payload. It's now **omitted by default**:

- `include_watch_providers: true` — include the full map
- `watch_provider_regions: ["US"]` — restrict to regions (implies inclusion)

**Breaking** (the default-behavior decision the issue punted): callers that relied on `watch_providers` being present must now opt in. Chosen because the primary consumer is an LLM/agent that won't know to pass flags — compact-by-default fixes the bomb at the source.

## #6 — book `compact` (single + batch)

`compact: true` (default `false`, opt-in) nulls `description` and empties `shelves`/`subjects` (the bulk), keeping genres, tropes, series, ratings, cover, and identifiers. `description` stays present by default since it's useful for Obsidian notes.

## Implementation

- Pure, cache-safe shaping functions: `shapeWatchProviders`, `compactBookResult` (never mutate the cached result).
- Wired into `lookup-movie`, `lookup-book`, and `batch-lookup`, with matching input-schema + type updates.

## Testing

**113 tests** (11 new): region filter incl. case-insensitive matching and implicit-inclusion, default-off wiring on `execute`, compact trimming + no-mutation guards. `lint` + `build` clean.

Closes #6, #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `compact` option for book lookups to trim response size by removing descriptions and large arrays.
  * Added watch provider controls for movie lookups: opt-in inclusion and region-based filtering.

* **Documentation**
  * Updated README with response shaping behavior details.

* **Tests**
  * Added comprehensive test coverage for response shaping features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->