### PR TITLE
feat(tools): lean-but-useful defaults (US watch_providers, compact books)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Look up book metadata by title, author, or ISBN.
 
 **Output:** Book metadata including title, authors, ISBN, genres, page count, description, cover URL, series information, and ratings.
 
-Optional `compact: true` trims the response — nulls `description` and drops the noisy `shelves`/`subjects` arrays (the bulk of the payload), keeping genres, tropes, series, ratings, cover, and identifiers. Useful for batch lookups that would otherwise exceed inline token limits.
+Responses are **compact by default** — `description` is nulled and the noisy `shelves`/`subjects` arrays dropped (the bulk of the payload), keeping genres, tropes, series, ratings, cover, and identifiers. This keeps batch lookups within inline token limits. Pass `compact: false` to get the full description back.
 
 ### lookup_movie
 
@@ -174,7 +174,7 @@ Look up movie metadata by title and optional year.
 
 **Output:** Movie metadata including title, year, runtime, genres, description, cast, director, collection info, ratings, and watch providers.
 
-By default the large ~100-region `watch_providers` map is **omitted** to keep responses compact. To include it, pass `include_watch_providers: true`, or restrict it to specific regions with `watch_provider_regions: ["US"]` (which implies inclusion).
+By default `watch_providers` returns the **`US` region only** — the full map spans ~100 regions and would otherwise dominate the payload. Pass `watch_provider_regions: ["GB", "US"]` to choose regions, `watch_provider_regions: []` for all ~100, or `include_watch_providers: false` to omit the map entirely.
 
 ### lookup_tv
 

--- a/src/tools/batch-lookup.ts
+++ b/src/tools/batch-lookup.ts
@@ -12,8 +12,8 @@ const BatchBookItemSchema = z.object({
   title: z.string().min(1),
   author: z.string().optional(),
   isbn: z.string().optional(),
-  compact: z.boolean().default(false)
-    .describe('Trim each book: null description, drop shelves/subjects (cuts most of the payload)'),
+  compact: z.boolean().default(true)
+    .describe('Trim each book (default): null description, drop shelves/subjects. Set false for full descriptions.'),
 });
 
 const BatchMovieItemSchema = z.object({
@@ -21,10 +21,10 @@ const BatchMovieItemSchema = z.object({
   title: z.string().min(1),
   year: z.number().int().optional(),
   tmdb_id: z.number().int().optional(),
-  include_watch_providers: z.boolean().default(false)
-    .describe('Include the ~100-region watch-providers map (off by default — large)'),
-  watch_provider_regions: z.array(z.string()).optional()
-    .describe('Restrict watch_providers to these ISO country codes, e.g. ["US"]. Implies inclusion.'),
+  include_watch_providers: z.boolean().default(true)
+    .describe('Include watch_providers. Set false to omit entirely.'),
+  watch_provider_regions: z.array(z.string()).default(['US'])
+    .describe('Restrict watch_providers to these ISO country codes. Defaults to ["US"]; pass [] for all regions.'),
 });
 
 const BatchTVItemSchema = z.object({

--- a/src/tools/lookup-book.ts
+++ b/src/tools/lookup-book.ts
@@ -16,8 +16,8 @@ export const LookupBookInputSchema = z.object({
     .array(z.enum(['open_library', 'google_books', 'goodreads', 'hardcover']))
     .optional()
     .describe('Sources to query (defaults to all available)'),
-  compact: z.boolean().default(false)
-    .describe('Trim the response: null the description and drop shelves/subjects (the bulk of the payload), keeping genres/tropes/series/ratings/cover/identifiers.'),
+  compact: z.boolean().default(true)
+    .describe('Trim the response (default): null the description and drop shelves/subjects (the bulk of the payload), keeping genres/tropes/series/ratings/cover/identifiers. Set false for the full description.'),
 });
 
 /**

--- a/src/tools/lookup-movie.ts
+++ b/src/tools/lookup-movie.ts
@@ -9,37 +9,39 @@ export const LookupMovieInputSchema = z.object({
     .describe('Release year (improves matching accuracy)'),
   tmdb_id: z.number().int().positive().optional()
     .describe('TMDB ID if known (preferred for exact match)'),
-  include_watch_providers: z.boolean().default(false)
-    .describe('Include the regional watch-providers map (large — ~100 regions). Off by default to keep responses compact.'),
-  watch_provider_regions: z.array(z.string()).optional()
-    .describe('Restrict watch_providers to these ISO country codes, e.g. ["US"]. Implies inclusion.'),
+  include_watch_providers: z.boolean().default(true)
+    .describe('Include watch_providers. Set false to omit the map entirely.'),
+  watch_provider_regions: z.array(z.string()).default(['US'])
+    .describe('Restrict watch_providers to these ISO country codes. Defaults to ["US"]; pass [] for all ~100 regions.'),
 });
 
 /**
  * Shape the regional watch-providers map per the caller's request. The full map
  * spans ~100 region keys and dominates the movie payload (a context bomb for
- * agents), so it is omitted unless explicitly asked for. A region filter implies
- * inclusion. Returns a new object — never mutates the (possibly cached) input.
+ * agents), so callers get a single region (US) by default. Precedence: an
+ * explicit `include_watch_providers: false` always wins (returns {}); otherwise
+ * a non-empty region list filters; an empty list returns all regions. Returns a
+ * new object — never mutates the (possibly cached) input.
  */
 export function shapeWatchProviders(
   providers: RegionalWatchProviders,
   opts: { includeWatchProviders: boolean; watchProviderRegions?: string[] }
 ): RegionalWatchProviders {
-  const hasRegionFilter = !!opts.watchProviderRegions && opts.watchProviderRegions.length > 0;
-  if (!opts.includeWatchProviders && !hasRegionFilter) {
+  if (!opts.includeWatchProviders) {
     return {};
   }
-  if (hasRegionFilter) {
-    const wanted = new Set(opts.watchProviderRegions!.map((r) => r.toUpperCase()));
-    const filtered: RegionalWatchProviders = {};
-    for (const [region, data] of Object.entries(providers)) {
-      if (wanted.has(region.toUpperCase())) {
-        filtered[region] = data;
-      }
-    }
-    return filtered;
+  const hasRegionFilter = !!opts.watchProviderRegions && opts.watchProviderRegions.length > 0;
+  if (!hasRegionFilter) {
+    return providers;
   }
-  return providers;
+  const wanted = new Set(opts.watchProviderRegions!.map((r) => r.toUpperCase()));
+  const filtered: RegionalWatchProviders = {};
+  for (const [region, data] of Object.entries(providers)) {
+    if (wanted.has(region.toUpperCase())) {
+      filtered[region] = data;
+    }
+  }
+  return filtered;
 }
 
 export class LookupMovieTool {

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -51,7 +51,7 @@ export const LookupBookInputSchema = z.object({
   author: z.string().optional(),
   isbn: z.string().optional(),
   sources: z.array(BookSourceSchema).optional(),
-  compact: z.boolean().default(false),
+  compact: z.boolean().default(true),
 });
 export type LookupBookInput = z.infer<typeof LookupBookInputSchema>;
 

--- a/src/types/movie.ts
+++ b/src/types/movie.ts
@@ -50,8 +50,8 @@ export const LookupMovieInputSchema = z.object({
   title: z.string().min(1, 'Title is required'),
   year: z.number().int().min(1800).max(2100).optional(),
   tmdb_id: z.number().int().positive().optional(),
-  include_watch_providers: z.boolean().default(false),
-  watch_provider_regions: z.array(z.string()).optional(),
+  include_watch_providers: z.boolean().default(true),
+  watch_provider_regions: z.array(z.string()).default(['US']),
 });
 export type LookupMovieInput = z.infer<typeof LookupMovieInputSchema>;
 

--- a/tests/tools/response-shaping.test.ts
+++ b/tests/tools/response-shaping.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { shapeWatchProviders, LookupMovieTool } from '../../src/tools/lookup-movie.js';
-import { compactBookResult } from '../../src/tools/lookup-book.js';
+import { shapeWatchProviders, LookupMovieTool, LookupMovieInputSchema } from '../../src/tools/lookup-movie.js';
+import { compactBookResult, LookupBookInputSchema } from '../../src/tools/lookup-book.js';
 import { Logger } from '../../src/utils/logger.js';
 import type { TMDBSource } from '../../src/sources/tmdb.js';
 import type { MovieResult, RegionalWatchProviders } from '../../src/types/movie.js';
@@ -21,9 +21,17 @@ describe('shapeWatchProviders (#30)', () => {
     expect(shapeWatchProviders(PROVIDERS, { includeWatchProviders: true })).toEqual(PROVIDERS);
   });
 
-  it('treats a region filter as implicit inclusion (even when include is false)', () => {
+  it('returns {} when include is false, even with a region filter (explicit opt-out wins)', () => {
     const out = shapeWatchProviders(PROVIDERS, {
       includeWatchProviders: false,
+      watchProviderRegions: ['US'],
+    });
+    expect(out).toEqual({});
+  });
+
+  it('filters to the given regions when included', () => {
+    const out = shapeWatchProviders(PROVIDERS, {
+      includeWatchProviders: true,
       watchProviderRegions: ['US'],
     });
     expect(Object.keys(out)).toEqual(['US']);
@@ -124,17 +132,38 @@ describe('LookupMovieTool watch_providers wiring (#30)', () => {
     return new LookupMovieTool(tmdb, new Logger('test'));
   }
 
-  it('omits watch_providers by default (opt-in compact)', async () => {
-    const res = await toolReturning(makeMovie()).execute({
+  it('returns only US watch_providers on a default lookup', async () => {
+    const input = LookupMovieInputSchema.parse({ title: 'The Matrix' });
+    const res = await toolReturning(makeMovie()).execute(input);
+    expect(Object.keys(res.watch_providers)).toEqual(['US']);
+  });
+
+  it('omits watch_providers entirely when include_watch_providers is false', async () => {
+    const input = LookupMovieInputSchema.parse({
       title: 'The Matrix', include_watch_providers: false,
     });
+    const res = await toolReturning(makeMovie()).execute(input);
     expect(res.watch_providers).toEqual({});
   });
 
-  it('includes only the requested region when watch_provider_regions is set', async () => {
-    const res = await toolReturning(makeMovie()).execute({
-      title: 'The Matrix', include_watch_providers: false, watch_provider_regions: ['US'],
+  it('returns all regions when watch_provider_regions is empty', async () => {
+    const input = LookupMovieInputSchema.parse({
+      title: 'The Matrix', watch_provider_regions: [],
     });
-    expect(Object.keys(res.watch_providers)).toEqual(['US']);
+    const res = await toolReturning(makeMovie()).execute(input);
+    expect(Object.keys(res.watch_providers).sort()).toEqual(['GB', 'US']);
+  });
+});
+
+describe('default input shapes', () => {
+  it('defaults movie lookups to US providers, included', () => {
+    const parsed = LookupMovieInputSchema.parse({ title: 'x' });
+    expect(parsed.include_watch_providers).toBe(true);
+    expect(parsed.watch_provider_regions).toEqual(['US']);
+  });
+
+  it('defaults book lookups to compact', () => {
+    const parsed = LookupBookInputSchema.parse({ title: 'x' });
+    expect(parsed.compact).toBe(true);
   });
 });


### PR DESCRIPTION
## What

Refines the response-shaping defaults from #6/#30 after dogfooding — "lean **and** useful" rather than "lean by omission":

- **Movies:** `watch_providers` now returns the **`US` region only** by default (was: omitted entirely). One useful region, tiny payload. `watch_provider_regions` defaults to `["US"]`; pass `[]` for all ~100 regions, specific codes to filter, or `include_watch_providers: false` to omit entirely.
- **Books:** `compact` now defaults to **`true`** (was `false`) — descriptions/shelves/subjects trimmed by default; pass `compact: false` to restore the full description.

## Semantics

`shapeWatchProviders` precedence is now: explicit `include_watch_providers: false` → `{}` (opt-out always wins) → non-empty region list filters → empty list returns all. (Previously a region filter implied inclusion; with US as the default region that's no longer needed and opt-out is cleaner.)

## Testing

**117 tests** (4 new/changed): opt-out-wins precedence, default→US wiring (via `schema.parse` to exercise real defaults), all-regions via `[]`, and default-shape assertions (`include` default true, regions default `["US"]`, book `compact` default true). lint + build clean. README updated.

Refines #6, #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation for book and movie lookup tools reflecting new defaults.

* **Updates**
  * Book lookups now return compact results by default, excluding full descriptions and metadata. Set `compact: false` to restore complete information.
  * Movie lookups now include watch provider availability by default, initially filtered to US region. Use `watch_provider_regions` to customize region selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->